### PR TITLE
Harden RLS identity, query, and role defaults (defense-in-depth, per MSRC review of VULN-219685)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,8 +1,16 @@
 POSTGRES_DB_HOST=pg17
 POSTGRES_DB_PORT=5432
 POSTGRES_DB=zava
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=change-me
+# The MCP server must NOT connect as "postgres" (or any other role with the
+# Superuser or BYPASSRLS attribute) - such a role silently bypasses every
+# Row Level Security policy in the database, regardless of any application-
+# level access control. POSTGRES_USER/POSTGRES_PASSWORD below connect as
+# store_manager, the non-superuser, SELECT-only role docker-init/init-db.sh
+# provisions for this purpose. If you change the role, verify it has neither
+# attribute (`\du <role>` in psql must not show Superuser or Bypass RLS).
+POSTGRES_USER=store_manager
+# Must match the store_manager password docker-init/init-db.sh creates.
+POSTGRES_PASSWORD=StoreManager123
 POSTGRES_APPLICATION_NAME=mcp-server
 
 # Azure secrets
@@ -16,3 +24,27 @@ AZURE_CLIENT_ID="YOUR_CLIENT_ID"
 AZURE_CLIENT_SECRET="YOUR_CLIENT_SECRET"
 AZURE_TENANT_ID="YOUR_TENANT_ID"
 AZURE_OPENAI_ENDPOINT="https://YOUR_OPENAI_RESOURCE_NAME.services.ai.azure.com/"
+
+# --- Caller identity (Row Level Security) ---
+# The server no longer trusts a client-supplied x-rls-user-id header. It
+# derives the RLS identity from a verified JWT bearer token instead - see
+# mcp_server/auth.py and walkthrough/02-Security/README.md.
+#
+# Production: set AZURE_TENANT_ID above AND set AZURE_AUDIENCE explicitly
+# (below). Both must be set for the server to verify inbound caller tokens -
+# AZURE_TENANT_ID/AZURE_CLIENT_ID above are also used for the server's own
+# outbound authentication to Azure OpenAI, so AZURE_AUDIENCE is required on
+# its own to make sure inbound verification only turns on when you mean it
+# to. Once both are set, the server verifies each caller's token against
+# your tenant's JWKS (signature, expiry, audience, issuer) and reads the RLS
+# identity from the verified token's "rls_user_id" claim (override the claim
+# name with AUTH_RLS_CLAIM). Your app registration needs an optional claim
+# or claims-mapping policy that emits that claim for signed-in store
+# managers.
+# AZURE_AUDIENCE="YOUR_CLIENT_ID"
+
+# Local/dev only, never for production: set this to a random value and sign
+# test tokens with scripts/generate_dev_token.py to run the sample without a
+# real Azure AD tenant. Leave both this and AZURE_AUDIENCE unset and every
+# request is rejected.
+# AUTH_DEV_HMAC_SECRET=

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -3,23 +3,28 @@
 		"zava-sales-analysis-headoffice": {
 			"url": "http://127.0.0.1:8000/mcp",
 			"type": "http",
-			"headers": {"x-rls-user-id": "00000000-0000-0000-0000-000000000000"}
+			"headers": {"Authorization": "Bearer ${input:headofficeToken}"}
 		},
 		"zava-sales-analysis-seattle": {
 			"url": "http://127.0.0.1:8000/mcp",
 			"type": "http",
-			"headers": {"x-rls-user-id": "f47ac10b-58cc-4372-a567-0e02b2c3d479"}
+			"headers": {"Authorization": "Bearer ${input:seattleToken}"}
 		},
 		"zava-sales-analysis-redmond": {
 			"url": "http://127.0.0.1:8000/mcp",
 			"type": "http",
-			"headers": {"x-rls-user-id": "e7f8a9b0-c1d2-3e4f-5678-90abcdef1234"}
+			"headers": {"Authorization": "Bearer ${input:redmondToken}"}
 		},
 		"zava-sales-analysis-online": {
 			"url": "http://127.0.0.1:8000/mcp",
 			"type": "http",
-			"headers": {"x-rls-user-id": "2f4e6d8c-1a3b-5c7e-9f0a-b2d4f6e8c0a2"}
+			"headers": {"Authorization": "Bearer ${input:onlineToken}"}
 		}
 	},
-	"inputs": []
+	"inputs": [
+		{"type": "promptString", "id": "headofficeToken", "description": "Bearer token for headoffice (RLS User ID 00000000-0000-0000-0000-000000000000) - generate with scripts/generate_dev_token.py", "password": true},
+		{"type": "promptString", "id": "seattleToken", "description": "Bearer token for Seattle (RLS User ID f47ac10b-58cc-4372-a567-0e02b2c3d479) - generate with scripts/generate_dev_token.py", "password": true},
+		{"type": "promptString", "id": "redmondToken", "description": "Bearer token for Redmond (RLS User ID e7f8a9b0-c1d2-3e4f-5678-90abcdef1234) - generate with scripts/generate_dev_token.py", "password": true},
+		{"type": "promptString", "id": "onlineToken", "description": "Bearer token for Online (RLS User ID 2f4e6d8c-1a3b-5c7e-9f0a-b2d4f6e8c0a2) - generate with scripts/generate_dev_token.py", "password": true}
+	]
 }

--- a/README.md
+++ b/README.md
@@ -271,6 +271,24 @@ docker compose logs -f pg17
 docker compose down -v
 ```
 
+### Configure a Local Test Identity
+
+The server verifies every caller's identity from a JWT bearer token - it no longer accepts a plain `x-rls-user-id` header (see [Row Level Security (RLS)](#row-level-security-rls) below). To run the stack locally without a real Azure Entra ID tenant:
+
+1. Add a random local signing secret to `.env` (never use this mode in a real deployment):
+
+    ```bash
+    echo "AUTH_DEV_HMAC_SECRET=$(openssl rand -hex 32)" >> .env
+    docker compose restart mcp_server
+    ```
+
+2. Mint a token for the store you want to query, using the same secret and one of the [Store-Specific RLS User IDs](#store-specific-rls-user-ids):
+
+    ```bash
+    export AUTH_DEV_HMAC_SECRET=<the value you just added to .env>
+    python scripts/generate_dev_token.py --rls-user-id f47ac10b-58cc-4372-a567-0e02b2c3d479
+    ```
+
 ## Usage
 
 The following assumes you'll be using the built-in VS Code MCP server support.
@@ -281,12 +299,12 @@ The following assumes you'll be using the built-in VS Code MCP server support.
     code .
     ```
 
-2. Start one or more MCP servers using the configurations in `.vscode/mcp.json`. The file contains four different server configurations, each representing a different store manager role:
+2. Start one or more MCP servers using the configurations in `.vscode/mcp.json`. The file contains four different server configurations, each representing a different store manager role. VS Code prompts for a bearer token the first time you connect each one - paste in a token generated as described above for that store's RLS User ID:
 
-   - Each configuration uses a unique RLS (Row Level Security) user ID
-   - These user IDs simulate different store manager identities accessing the database
-   - The RLS system restricts data access based on the manager's assigned store
-   - This mimics real-world scenarios where store managers sign in with different Entra ID accounts
+   - Each configuration corresponds to a different store manager role
+   - Generate each token with `scripts/generate_dev_token.py --rls-user-id <RLS User ID>` (see [Configure a Local Test Identity](#configure-a-local-test-identity))
+   - The RLS system restricts data access based on the verified token's identity
+   - This mimics real-world scenarios where store managers sign in with different Entra ID accounts and are issued tokens scoped to their store
 
     ```json
     {
@@ -294,25 +312,30 @@ The following assumes you'll be using the built-in VS Code MCP server support.
             "zava-sales-analysis-headoffice": {
                 "url": "http://127.0.0.1:8000/mcp",
                 "type": "http",
-                "headers": {"x-rls-user-id": "00000000-0000-0000-0000-000000000000"}
+                "headers": {"Authorization": "Bearer ${input:headofficeToken}"}
             },
             "zava-sales-analysis-seattle": {
                 "url": "http://127.0.0.1:8000/mcp",
                 "type": "http",
-                "headers": {"x-rls-user-id": "f47ac10b-58cc-4372-a567-0e02b2c3d479"}
+                "headers": {"Authorization": "Bearer ${input:seattleToken}"}
             },
             "zava-sales-analysis-redmond": {
                 "url": "http://127.0.0.1:8000/mcp",
                 "type": "http",
-                "headers": {"x-rls-user-id": "e7f8a9b0-c1d2-3e4f-5678-90abcdef1234"}
+                "headers": {"Authorization": "Bearer ${input:redmondToken}"}
             },
             "zava-sales-analysis-online": {
                 "url": "http://127.0.0.1:8000/mcp",
                 "type": "http",
-                "headers": {"x-rls-user-id": "2f4e6d8c-1a3b-5c7e-9f0a-b2d4f6e8c0a2"}
+                "headers": {"Authorization": "Bearer ${input:onlineToken}"}
             }
         },
-        "inputs": []
+        "inputs": [
+            {"type": "promptString", "id": "headofficeToken", "description": "Bearer token for headoffice (RLS User ID 00000000-0000-0000-0000-000000000000)", "password": true},
+            {"type": "promptString", "id": "seattleToken", "description": "Bearer token for Seattle (RLS User ID f47ac10b-58cc-4372-a567-0e02b2c3d479)", "password": true},
+            {"type": "promptString", "id": "redmondToken", "description": "Bearer token for Redmond (RLS User ID e7f8a9b0-c1d2-3e4f-5678-90abcdef1234)", "password": true},
+            {"type": "promptString", "id": "onlineToken", "description": "Bearer token for Online (RLS User ID 2f4e6d8c-1a3b-5c7e-9f0a-b2d4f6e8c0a2)", "password": true}
+        ]
     }
     ```
 
@@ -404,17 +427,17 @@ Perform a semantic search for products based on user queries.
 
 The server implements Row Level Security to ensure users only access data they're authorized to view:
 
-- **HTTP Mode**: Uses `x-rls-user-id` header to identify the requesting user
+- **Caller identity comes from a verified JWT**: HTTP requests authenticate with an `Authorization: Bearer <token>` header. The server verifies the token's signature, expiry, audience, and issuer (against Azure Entra ID in production, or a local shared secret for sample/dev use - see [`mcp_server/auth.py`](mcp_server/auth.py) and [Configure a Local Test Identity](#configure-a-local-test-identity)) and reads the RLS user id from a claim in the verified token. The `x-rls-user-id` header is no longer read or trusted - a client can no longer choose its own identity by sending an arbitrary header.
 
-- **Default Fallback**: Uses placeholder UUID when no user ID is provided
+- **No default identity**: if no valid, verified token is supplied, the request is rejected. There is no fallback to any store's data, including the all-store value below.
 
 #### Store-Specific RLS User IDs
 
-Each Zava Retail store location has a unique RLS user ID that determines which data the user can access:
+Each Zava Retail store location has a unique RLS user ID that determines which data a verified caller can access. These values only take effect when they arrive inside a verified token's claim - they are meaningless as plain text on their own:
 
 | Store Location | RLS User ID | Description |
 |---------------|-------------|-------------|
-| **Global Access** | `00000000-0000-0000-0000-000000000000` | Default fallback - all store access |
+| **Global Access** | `00000000-0000-0000-0000-000000000000` | Unconditional access to every store's data. The RLS policies treat this exact value as an "all stores" bypass, not a per-store scope - treat it like an admin credential and only issue it to callers who should see every store, never as a default. |
 | **Seattle** | `f47ac10b-58cc-4372-a567-0e02b2c3d479` | Zava Retail Seattle store data |
 | **Bellevue** | `6ba7b810-9dad-11d1-80b4-00c04fd430c8` | Zava Retail Bellevue store data |
 | **Tacoma** | `a1b2c3d4-e5f6-7890-abcd-ef1234567890` | Zava Retail Tacoma store data |
@@ -426,14 +449,14 @@ Each Zava Retail store location has a unique RLS user ID that determines which d
 
 #### RLS Implementation
 
-When a user connects with a specific store's RLS User ID, they will only see:
+When a caller presents a verified token whose claim carries a specific store's RLS User ID, they will only see:
 
 - Customers associated with that store
 - Orders placed at that store location
 - Inventory data for that specific store
 - Store-specific sales and performance metrics
 
-This ensures data isolation between different store locations while maintaining a unified database schema.
+This ensures data isolation between different store locations while maintaining a unified database schema. Data isolation additionally depends on the database role the server connects as having neither the `Superuser` nor `BYPASSRLS` attribute - see `.env.template` and `docker-init/init-db.sh`; either attribute silently bypasses every RLS policy regardless of the caller's identity.
 
 ## Architecture
 
@@ -447,8 +470,8 @@ The server uses a managed application context with:
 
 ### Request Context
 
-- **Header Extraction**: Secure header parsing for user identification
-- **RLS Integration**: Automatic user ID resolution from request context
+- **Verified Identity**: RLS user id resolved from a verified JWT bearer token, not a client-supplied header (see [Row Level Security (RLS)](#row-level-security-rls))
+- **RLS Integration**: Automatic user ID resolution from the verified token
 - **Error Handling**: Comprehensive error handling with user-friendly messages
 
 ## Database Integration
@@ -482,7 +505,7 @@ The server implements robust error handling:
 
 - **Never use production RLS User IDs in development environments**
 - **Always verify the RLS User ID matches the intended store before running queries**
-- **The default UUID (`00000000-0000-0000-0000-000000000000`) provides limited access**
+- **The default UUID (`00000000-0000-0000-0000-000000000000`) grants unconditional access to every store, not limited access - issue it only to callers who genuinely need all-store visibility**
 - **Each store manager should only have access to their store's RLS User ID**
 
 ## Development

--- a/Sample_Walkthrough.md
+++ b/Sample_Walkthrough.md
@@ -222,8 +222,12 @@ async def execute_sales_query(
     postgresql_query: Annotated[str, Field(description="A well-formed PostgreSQL query.")],
 ) -> str:
     """Execute PostgreSQL queries with Row Level Security."""
-    rls_user_id = get_rls_user_id(ctx)
-    
+    try:
+        rls_user_id = get_rls_user_id(ctx)
+    except AuthenticationError as e:
+        logger.warning("Rejecting unauthenticated execute_sales_query request: %s", e)
+        return f"Error: Authentication required - {e}"
+
     try:
         return await db_provider.execute_query(
             postgresql_query, rls_user_id=rls_user_id
@@ -235,20 +239,20 @@ async def execute_sales_query(
 
 **Key Features:**
 - **Type Annotations**: Pydantic field descriptions for AI understanding
-- **Context Extraction**: User identity from HTTP headers
+- **Verified Identity**: User identity from a verified JWT bearer token, not a raw HTTP header
+- **Fail Closed**: Missing or invalid identity rejects the request rather than falling back to a default
 - **Error Handling**: Graceful failure with informative messages
 - **Logging**: Comprehensive operation logging
 
 #### Request Context Management
 ```python
 def get_rls_user_id(ctx: Context) -> str:
-    """Extract Row Level Security User ID from request context."""
-    rls_user_id = get_header(ctx, "x-rls-user-id")
-    if rls_user_id is None:
-        # Default to placeholder if not provided
-        rls_user_id = "00000000-0000-0000-0000-000000000000"
-    return rls_user_id
+    """Get the Row Level Security User ID from a verified request identity."""
+    authorization = get_header(ctx, "authorization")
+    return get_verified_rls_user_id(authorization)
 ```
+
+`get_verified_rls_user_id` (in `mcp_server/auth.py`) verifies the bearer token's signature, expiry, audience, and issuer, then reads the RLS user id from a claim in the verified token. There is no default identity - a missing or invalid token raises `AuthenticationError`, which callers must treat as a rejection, not fall back from. See [Security and Multi-Tenancy](walkthrough/02-Security/README.md).
 
 ### Database Layer (`sales_analysis_postgres.py`)
 
@@ -493,20 +497,27 @@ fi
 ### VS Code Integration
 
 #### 1. **MCP Configuration (`.vscode/mcp.json`)**
+
+The server verifies each caller's identity from a JWT bearer token - see [Configure a Local Test Identity](README.md#configure-a-local-test-identity) for how to generate one locally with `scripts/generate_dev_token.py`. VS Code's `${input:...}` prompts for the token when you connect:
+
 ```json
 {
     "servers": {
         "zava-sales-analysis-headoffice": {
             "url": "http://127.0.0.1:8000/mcp",
             "type": "http",
-            "headers": {"x-rls-user-id": "00000000-0000-0000-0000-000000000000"}
+            "headers": {"Authorization": "Bearer ${input:headofficeToken}"}
         },
         "zava-sales-analysis-seattle": {
             "url": "http://127.0.0.1:8000/mcp",
-            "type": "http", 
-            "headers": {"x-rls-user-id": "f47ac10b-58cc-4372-a567-0e02b2c3d479"}
+            "type": "http",
+            "headers": {"Authorization": "Bearer ${input:seattleToken}"}
         }
-    }
+    },
+    "inputs": [
+        {"type": "promptString", "id": "headofficeToken", "description": "Bearer token for headoffice (RLS User ID 00000000-0000-0000-0000-000000000000)", "password": true},
+        {"type": "promptString", "id": "seattleToken", "description": "Bearer token for Seattle (RLS User ID f47ac10b-58cc-4372-a567-0e02b2c3d479)", "password": true}
+    ]
 }
 ```
 

--- a/azd/.env.local
+++ b/azd/.env.local
@@ -18,11 +18,13 @@
 
 # PostgreSQL Database (for future integration)
 # These can be customized for local development
+# POSTGRES_USER must be a non-superuser, non-BYPASSRLS role - see
+# docker-init/init-db.sh, which provisions store_manager for this purpose.
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 POSTGRES_DB=zava
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=change-me
+POSTGRES_USER=store_manager
+POSTGRES_PASSWORD=StoreManager123
 POSTGRES_APPLICATION_NAME=mcp-server
 
 # Container Apps (will be populated by azd)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,13 @@ services:
       - .env
     environment:
       - POSTGRES_INITDB_ARGS=--auth-host=scram-sha-256 --auth-local=scram-sha-256
+      # .env's POSTGRES_USER is the non-superuser role the MCP server
+      # connects as (see .env.template) and must stay separate from the
+      # superuser this image bootstraps itself with on first init, which
+      # docker-init/init-db.sh always addresses as "postgres". Pin it here
+      # so the two don't collide regardless of what POSTGRES_USER is set to
+      # for the mcp_server service below.
+      - POSTGRES_USER=postgres
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./data:/backup_data:ro

--- a/docker-init/init-db.sh
+++ b/docker-init/init-db.sh
@@ -57,8 +57,14 @@ if [ -f "$BACKUP_FILE" ]; then
   psql -U postgres -d zava -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO store_manager;" || true
   psql -U postgres -d zava -c "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO store_manager;" || true
   psql -U postgres -d zava -c "GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO store_manager;" || true
-  psql -U postgres -d zava -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA retail TO store_manager;" || true
-  psql -U postgres -d zava -c "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA retail TO store_manager;" || true
+  # store_manager is the RLS-scoped, read-only role the MCP server connects
+  # as by default (see .env.template). It must only ever get SELECT on the
+  # retail schema - granting ALL PRIVILEGES here would let any caller who
+  # can reach execute_sales_query write through this role regardless of
+  # what RLS policies allow, which previously overrode the SELECT-only
+  # grants already present in the backup file itself.
+  psql -U postgres -d zava -c "GRANT USAGE ON SCHEMA retail TO store_manager;" || true
+  psql -U postgres -d zava -c "GRANT SELECT ON ALL TABLES IN SCHEMA retail TO store_manager;" || true
   
   echo "Database restoration completed."
 else

--- a/infra/deploy.ps1
+++ b/infra/deploy.ps1
@@ -169,8 +169,11 @@ $gptModelLine = if ($includeGptModel) {
 POSTGRES_DB_HOST=pg17
 POSTGRES_DB_PORT=5432
 POSTGRES_DB="zava"
-POSTGRES_USER="postgres"
-POSTGRES_PASSWORD="change-me"
+# Must be a non-superuser, non-BYPASSRLS role - see docker-init/init-db.sh,
+# which provisions store_manager as a SELECT-only role for exactly this
+# reason. Connecting as "postgres" would silently bypass every RLS policy.
+POSTGRES_USER="store_manager"
+POSTGRES_PASSWORD="StoreManager123"
 POSTGRES_APPLICATION_NAME="mcp-server"
 PROJECT_ENDPOINT=$PROJECTS_ENDPOINT
 AZURE_OPENAI_ENDPOINT=$AZURE_OPENAI_ENDPOINT

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -147,8 +147,11 @@ cat > "$ENV_FILE_PATH" << EOF
 POSTGRES_DB_HOST=pg17
 POSTGRES_DB_PORT=5432
 POSTGRES_DB="zava"
-POSTGRES_USER="postgres"
-POSTGRES_PASSWORD="change-me"
+# Must be a non-superuser, non-BYPASSRLS role - see docker-init/init-db.sh,
+# which provisions store_manager as a SELECT-only role for exactly this
+# reason. Connecting as "postgres" would silently bypass every RLS policy.
+POSTGRES_USER="store_manager"
+POSTGRES_PASSWORD="StoreManager123"
 POSTGRES_APPLICATION_NAME="mcp-server"
 PROJECT_ENDPOINT=$PROJECTS_ENDPOINT
 AZURE_OPENAI_ENDPOINT=$AZURE_OPENAI_ENDPOINT

--- a/mcp_server/auth.py
+++ b/mcp_server/auth.py
@@ -1,0 +1,198 @@
+"""
+JWT-based authentication for the MCP server's Row Level Security identity.
+
+This replaces blind trust in the client-supplied `x-rls-user-id` header with
+an RLS user id derived from a verified JWT bearer token, wiring the Azure
+Entra ID validation approach sketched in walkthrough/02-Security/README.md
+into the actual server.
+
+Two verification modes are supported, selected automatically from
+configuration:
+
+1. Azure Entra ID (for a real deployment). Set both AZURE_TENANT_ID and
+   AZURE_AUDIENCE explicitly. (AZURE_TENANT_ID/AZURE_CLIENT_ID are also used
+   for the server's own outbound authentication to Azure OpenAI and can be
+   populated by infra/deploy.sh for that unrelated reason, so AZURE_AUDIENCE
+   is deliberately required on its own - this mode only turns on when it is
+   set on purpose.) The server fetches the tenant's JWKS from Microsoft's
+   discovery endpoint and verifies the token's RS256 signature, expiry,
+   audience, and issuer.
+
+2. Local/dev shared-secret mode (sample only, never for production). Set
+   AUTH_DEV_HMAC_SECRET to a random value and sign test tokens with
+   scripts/generate_dev_token.py. This lets the sample and its walkthrough
+   run end-to-end without a real Azure AD tenant. There is no key rotation
+   and no issuer check in this mode - anyone holding the shared secret can
+   mint any identity, so it must stay off in any real deployment.
+
+If neither is configured, every request is rejected. There is no
+unauthenticated fallback identity.
+
+In both modes the verified token must carry a claim - named by
+AUTH_RLS_CLAIM, default "rls_user_id" - whose value is the RLS identity to
+apply (a store's `stores.rls_user_id`, or the documented all-store value).
+A real Entra ID deployment needs an optional claim or claims-mapping policy
+on its app registration to emit this claim (or AUTH_RLS_CLAIM can be
+pointed at whatever claim the tenant already emits, e.g. a custom security
+attribute), so that a verified token - not client-supplied text - decides
+which store's data a caller can see.
+"""
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+import jwt
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+class AuthenticationError(Exception):
+    """Raised when a request cannot be tied to a verified RLS identity.
+
+    Callers must treat this as a hard failure and reject the request -
+    never fall back to a default or unauthenticated identity.
+    """
+
+
+def _clean(value: str) -> str:
+    """Strip surrounding quotes that Docker's env_file directive may leave in place."""
+    return value.strip('"').strip("'") if value else ""
+
+
+_AZURE_TENANT_ID = _clean(os.getenv("AZURE_TENANT_ID", ""))
+# Deliberately NOT falling back to AZURE_CLIENT_ID here. AZURE_TENANT_ID and
+# AZURE_CLIENT_ID are also used for the server's own outbound authentication
+# to Azure OpenAI (see .env.template) and get populated automatically by
+# infra/deploy.sh and infra/deploy.ps1 for that unrelated purpose. Inbound
+# caller-token verification must only turn on when AZURE_AUDIENCE is set
+# deliberately for that purpose - never as a side effect of those scripts.
+_AZURE_AUDIENCE = _clean(os.getenv("AZURE_AUDIENCE", ""))
+_AUTH_ISSUER = _clean(os.getenv("AUTH_ISSUER", ""))
+_AUTH_JWKS_URI = _clean(os.getenv("AUTH_JWKS_URI", ""))
+_AUTH_DEV_HMAC_SECRET = _clean(os.getenv("AUTH_DEV_HMAC_SECRET", ""))
+_AUTH_RLS_CLAIM = _clean(os.getenv("AUTH_RLS_CLAIM", "")) or "rls_user_id"
+
+# .env.template ships these as literal placeholders; treat them as "unset".
+_PLACEHOLDER_VALUES = {"", "YOUR_TENANT_ID", "YOUR_CLIENT_ID"}
+
+
+def _entra_configured() -> bool:
+    return (
+        _AZURE_TENANT_ID not in _PLACEHOLDER_VALUES
+        and _AZURE_AUDIENCE not in _PLACEHOLDER_VALUES
+    )
+
+
+def _issuer() -> str:
+    return _AUTH_ISSUER or f"https://login.microsoftonline.com/{_AZURE_TENANT_ID}/v2.0"
+
+
+def _jwks_uri() -> str:
+    return (
+        _AUTH_JWKS_URI
+        or f"https://login.microsoftonline.com/{_AZURE_TENANT_ID}/discovery/v2.0/keys"
+    )
+
+
+_jwks_client: Optional["jwt.PyJWKClient"] = None
+
+
+def _get_jwks_client() -> "jwt.PyJWKClient":
+    global _jwks_client
+    if _jwks_client is None:
+        # cache_keys/lifespan avoid a network round trip to Microsoft's JWKS
+        # endpoint on every request; keys are re-fetched hourly or on a
+        # cache miss (e.g. after Microsoft rotates a signing key).
+        _jwks_client = jwt.PyJWKClient(_jwks_uri(), cache_keys=True, lifespan=3600)
+    return _jwks_client
+
+
+def _verify_entra_token(token: str) -> Dict[str, Any]:
+    # _entra_configured() already guarantees AZURE_TENANT_ID and
+    # AZURE_AUDIENCE are both set before this is called.
+    signing_key = _get_jwks_client().get_signing_key_from_jwt(token)
+    return jwt.decode(
+        token,
+        signing_key.key,
+        algorithms=["RS256"],
+        audience=_AZURE_AUDIENCE,
+        issuer=_issuer(),
+        options={"require": ["exp", "iss", "aud"]},
+    )
+
+
+def _verify_dev_token(token: str) -> Dict[str, Any]:
+    logger.warning(
+        "Verifying request using AUTH_DEV_HMAC_SECRET - this is a sample/testing "
+        "mode only and must never be enabled in a real deployment."
+    )
+    return jwt.decode(
+        token,
+        _AUTH_DEV_HMAC_SECRET,
+        algorithms=["HS256"],
+        options={"require": ["exp"]},
+    )
+
+
+def _verify_token(token: str) -> Dict[str, Any]:
+    if _entra_configured():
+        return _verify_entra_token(token)
+    if _AUTH_DEV_HMAC_SECRET:
+        return _verify_dev_token(token)
+    raise AuthenticationError(
+        "No identity provider is configured. Set AZURE_TENANT_ID (and "
+        "AZURE_AUDIENCE) for Azure Entra ID verification, or "
+        "AUTH_DEV_HMAC_SECRET for local/dev testing - see README.md. "
+        "Refusing to guess the caller's identity."
+    )
+
+
+def auth_configured() -> bool:
+    """True if either verification mode has been configured."""
+    return _entra_configured() or bool(_AUTH_DEV_HMAC_SECRET)
+
+
+def get_verified_rls_user_id(authorization_header: Optional[str]) -> str:
+    """Verify the bearer token in `authorization_header` and return the RLS
+    user id from its verified claims.
+
+    Raises AuthenticationError if the header is missing or malformed, the
+    token fails verification (bad signature, expired, wrong audience or
+    issuer), or the verified token has no usable AUTH_RLS_CLAIM claim.
+    There is no default - callers must fail closed on this exception.
+    """
+    if not authorization_header:
+        raise AuthenticationError("Missing Authorization header")
+
+    scheme, _, token = authorization_header.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise AuthenticationError("Authorization header must be 'Bearer <token>'")
+
+    try:
+        payload = _verify_token(token)
+    except AuthenticationError:
+        raise
+    except jwt.ExpiredSignatureError as e:
+        raise AuthenticationError("Token has expired") from e
+    except jwt.PyJWTError as e:
+        # Covers every other PyJWT failure mode - malformed tokens, bad
+        # signatures, wrong audience/issuer, and JWKS lookup failures (e.g.
+        # jwt.PyJWKClientError for a token with no/unknown `kid`) all land
+        # here so they fail closed the same way rather than propagating as
+        # an unhandled exception.
+        raise AuthenticationError(f"Token validation failed: {e}") from e
+
+    rls_user_id = payload.get(_AUTH_RLS_CLAIM)
+    if not rls_user_id or not isinstance(rls_user_id, str):
+        raise AuthenticationError(
+            f"Verified token has no usable '{_AUTH_RLS_CLAIM}' claim"
+        )
+    return rls_user_id

--- a/mcp_server/sales_analysis.py
+++ b/mcp_server/sales_analysis.py
@@ -13,6 +13,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from opentelemetry.instrumentation.starlette import StarletteInstrumentor
 from pydantic import Field
 
+from .auth import AuthenticationError, auth_configured, get_verified_rls_user_id
 from .config import Config
 from .sales_analysis_postgres import PostgreSQLSchemaProvider
 from .sales_analysis_text_embeddings import SemanticSearchTextEmbedding
@@ -58,13 +59,18 @@ def get_header(ctx: Context, header_name: str) -> Optional[str]:
 
 
 def get_rls_user_id(ctx: Context) -> str:
-    """Get the Row Level Security User ID from the request context."""
+    """Get the Row Level Security User ID from a verified request identity.
 
-    rls_user_id = get_header(ctx, "x-rls-user-id")
-    if rls_user_id is None:
-        # Default to a placeholder if not provided
-        rls_user_id = "00000000-0000-0000-0000-000000000000"
-    return rls_user_id
+    The RLS identity is no longer taken from the client-supplied
+    `x-rls-user-id` header. It is derived from a verified JWT bearer token
+    (see auth.py), so a caller can no longer claim another store's - or the
+    all-store - identity by sending an arbitrary header. Raises
+    AuthenticationError if no valid identity is supplied; callers must fail
+    closed on that error rather than falling back to a default.
+    """
+
+    authorization = get_header(ctx, "authorization")
+    return get_verified_rls_user_id(authorization)
 
 
 @mcp.tool()
@@ -99,7 +105,11 @@ async def semantic_search_products(
           {"err":"...","q":"SELECT ...","c":[],"r":[],"n":0}
     """
 
-    rls_user_id = get_rls_user_id(ctx)
+    try:
+        rls_user_id = get_rls_user_id(ctx)
+    except AuthenticationError as e:
+        logger.warning("Rejecting unauthenticated semantic_search_products request: %s", e)
+        return f"Error: Authentication required - {e}"
 
     logger.info("Semantic search query: %s", query_description)
     logger.info("Manager ID: %s", rls_user_id)
@@ -152,7 +162,11 @@ async def get_multiple_table_schemas(
         Concatenated schema strings for the requested tables.
     """
 
-    rls_user_id = get_rls_user_id(ctx)
+    try:
+        rls_user_id = get_rls_user_id(ctx)
+    except AuthenticationError as e:
+        logger.warning("Rejecting unauthenticated get_multiple_table_schemas request: %s", e)
+        return f"Error: Authentication required - {e}"
 
     if not table_names:
         logger.error("Error: table_names parameter is required and cannot be empty")
@@ -207,7 +221,11 @@ async def execute_sales_query(
         Query results as a string.
     """
 
-    rls_user_id = get_rls_user_id(ctx)
+    try:
+        rls_user_id = get_rls_user_id(ctx)
+    except AuthenticationError as e:
+        logger.warning("Rejecting unauthenticated execute_sales_query request: %s", e)
+        return f"Error: Authentication required - {e}"
 
     logger.info("Manager ID: %s", rls_user_id)
     logger.info("Executing PostgreSQL query: %s", postgresql_query)
@@ -243,6 +261,13 @@ async def get_current_utc_date() -> str:
 
 async def run_http_server() -> None:
     """Run the MCP server in HTTP mode."""
+
+    if not auth_configured():
+        logger.warning(
+            "No identity provider is configured (AZURE_TENANT_ID or "
+            "AUTH_DEV_HMAC_SECRET). All tool calls will be rejected until one "
+            "is set - see README.md#security-features."
+        )
 
     # Only configure azure monitor if a valid connection string is provided.
     appinsights_connection_string = config.applicationinsights_connection_string

--- a/mcp_server/sales_analysis_postgres.py
+++ b/mcp_server/sales_analysis_postgres.py
@@ -18,6 +18,7 @@ Requirements:
 import asyncio
 import json
 import logging
+import re
 from typing import Any, Dict, List, Optional
 
 import asyncpg
@@ -38,6 +39,52 @@ POSTGRES_CONNECTION_PARAMS = config.get_postgres_connection_params()
 
 SCHEMA_NAME = "retail"
 MANAGER_ID = ""
+
+# Matches a leading run of whitespace and SQL comments so the real first
+# keyword of a query can be checked even when it's preceded by a comment.
+_LEADING_COMMENT_RE = re.compile(r"\A\s*(--[^\n]*(\n|\Z)|/\*.*?\*/)\s*", re.DOTALL)
+
+
+def _first_keyword(sql_query: str) -> str:
+    """Return the lowercased first SQL keyword, skipping leading whitespace/comments."""
+    text = sql_query
+    while True:
+        match = _LEADING_COMMENT_RE.match(text)
+        if not match:
+            break
+        text = text[match.end():]
+    text = text.lstrip()
+    match = re.match(r"[A-Za-z_][A-Za-z_0-9]*", text)
+    return match.group(0).lower() if match else ""
+
+
+def _is_read_only_query(sql_query: str) -> bool:
+    """Best-effort check that `sql_query` is a single read-only statement.
+
+    This rejects anything that isn't a SELECT or WITH (CTE) statement, and
+    rejects stacked statements (more than one top-level statement separated
+    by ';'). It is intentionally conservative - a semicolon inside a string
+    literal will also be rejected - because false positives here just mean a
+    query has to be rephrased, while false negatives would reopen the write
+    path this check exists to close.
+
+    This is a defense-in-depth layer, not the only one: execute_query also
+    runs the statement inside a READ ONLY transaction, so PostgreSQL itself
+    rejects any write even if this check is bypassed - for example via a
+    data-modifying CTE such as `WITH t AS (INSERT INTO ... RETURNING *)
+    SELECT * FROM t`, which passes this string-level check but is still a
+    write.
+    """
+    if not sql_query or not sql_query.strip():
+        return False
+
+    body = sql_query.strip()
+    if body.endswith(";"):
+        body = body[:-1]
+    if ";" in body:
+        return False
+
+    return _first_keyword(body) in ("select", "with")
 
 # Constants - table names without schema prefix (will be added in queries)
 CUSTOMERS_TABLE = "customers"
@@ -760,7 +807,7 @@ class PostgreSQLSchemaProvider:
         return schema_data
 
     async def execute_query(self, sql_query: str, rls_user_id: str) -> str:
-        """Execute a SQL query and return results in compact JSON.
+        """Execute a read-only SQL query and return results in compact JSON.
 
         Compact success shape:
           {"c":["col1","col2"],"r":[[v11,v12],[v21,v22]],"n":2}
@@ -768,7 +815,29 @@ class PostgreSQLSchemaProvider:
           {"c":[],"r":[],"n":0,"msg":"No rows"}
         Error shape:
           {"err":"...","q":"SELECT ...","c":[],"r":[],"n":0}
+
+        Enforces read-only access in two layers: `sql_query` must parse as a
+        single SELECT/WITH statement (see _is_read_only_query), and the
+        statement itself runs inside a READ ONLY transaction so PostgreSQL
+        rejects any write even if the first check is bypassed.
         """
+        if not _is_read_only_query(sql_query):
+            return json.dumps(
+                {
+                    "err": (
+                        "Only a single, read-only SELECT/WITH statement is "
+                        "permitted. Writes, DDL, and stacked statements are "
+                        "not allowed."
+                    ),
+                    "q": sql_query,
+                    "c": [],
+                    "r": [],
+                    "n": 0,
+                },
+                separators=(",", ":"),
+                default=str,
+            )
+
         conn: Optional[asyncpg.Connection] = None
         try:
             conn = await self.get_connection()
@@ -776,7 +845,8 @@ class PostgreSQLSchemaProvider:
                 "SELECT set_config('app.current_rls_user_id', $1, false)", rls_user_id
             )
 
-            rows = await conn.fetch(sql_query)
+            async with conn.transaction(readonly=True):
+                rows = await conn.fetch(sql_query)
             if not rows:
                 return json.dumps(
                     {"c": [], "r": [], "n": 0, "msg": "No rows"},

--- a/requirements.in
+++ b/requirements.in
@@ -16,6 +16,7 @@ asyncpg>=0.30.0,<0.31.0
 azure-identity>=1.23.0,<2.0.0
 azure-monitor-opentelemetry>=1.6.10,<2.0.0
 openai>=1.98.0,<2.0.0
+pyjwt[crypto]>=2.13.0,<3.0.0
 
 # Data processing and utilities
 pydantic>=2.0.0,<3.0.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -214,6 +214,7 @@ pydantic-settings==2.10.1
     # via mcp
 pyjwt[crypto]==2.13.0
     # via
+    #   -r requirements.in
     #   mcp
     #   msal
 python-dotenv==1.1.1

--- a/scripts/generate_dev_token.py
+++ b/scripts/generate_dev_token.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+Mint a local test JWT for the sample's AUTH_DEV_HMAC_SECRET auth mode.
+
+This is a development/testing convenience only. It has nothing to do with
+Azure Entra ID and must never be used against a real deployment - a real
+deployment authenticates callers through Entra ID (see
+walkthrough/02-Security/README.md and mcp_server/auth.py), where tokens are
+issued by Microsoft, not by this script.
+
+Usage:
+    export AUTH_DEV_HMAC_SECRET=some-random-local-only-value
+    python scripts/generate_dev_token.py --rls-user-id f47ac10b-58cc-4372-a567-0e02b2c3d479
+
+Then call the server with:
+    curl -H "Authorization: Bearer <token printed above>" ...
+"""
+
+import argparse
+import os
+import sys
+import time
+
+import jwt
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--rls-user-id",
+        required=True,
+        help="The RLS user id to embed (a store's rls_user_id, or the "
+        "documented all-store value).",
+    )
+    parser.add_argument(
+        "--expires-in-seconds",
+        type=int,
+        default=3600,
+        help="Token lifetime in seconds. Defaults to 3600 (1 hour).",
+    )
+    args = parser.parse_args()
+
+    secret = os.getenv("AUTH_DEV_HMAC_SECRET", "")
+    if not secret:
+        print(
+            "Error: AUTH_DEV_HMAC_SECRET is not set. Export the same value the "
+            "MCP server is configured with before running this script.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    claim_name = os.getenv("AUTH_RLS_CLAIM", "rls_user_id")
+    now = int(time.time())
+    payload = {
+        claim_name: args.rls_user_id,
+        "iat": now,
+        "exp": now + args.expires_in_seconds,
+    }
+    token = jwt.encode(payload, secret, algorithm="HS256")
+    print(token)
+
+
+if __name__ == "__main__":
+    main()

--- a/walkthrough/02-Security/README.md
+++ b/walkthrough/02-Security/README.md
@@ -264,6 +264,15 @@ $$;
 
 ## 🔑 Authentication and Authorization
 
+> A simpler version of the JWT verification sketched below - signature check
+> via a configurable JWKS/issuer, expiry check, and RLS claim extraction,
+> without the Key Vault-backed store-mapping lookup - is actually wired into
+> the running server at [`mcp_server/auth.py`](../../mcp_server/auth.py) and
+> [`mcp_server/sales_analysis.py`](../../mcp_server/sales_analysis.py). This
+> section remains a broader illustration of a full production authorization
+> layer (role hierarchy, Key Vault-backed store mapping, audit logging) that
+> you can grow into.
+
 ### Azure Entra ID Integration
 
 ```python


### PR DESCRIPTION
## Summary

MSRC reviewed a security report against this sample (VULN-219685), correctly closed it as non-CVE-eligible since it's a teaching sample rather than a live service, and suggested five defense-in-depth hardening changes. This PR implements all five.

None of this is presented as fixing a live vulnerability in a hosted service - it's hardening a local sample and its walkthrough so the patterns it teaches (RLS identity handling, least-privilege roles, read-only query tools) are ones a learner could actually carry into production.

## Changes

**1. Verified JWT identity instead of a client-supplied header**

`get_rls_user_id()` used to read the `x-rls-user-id` header directly and default to the all-stores UUID when it was missing, so any caller could claim any store's identity with nothing to check it. Added `mcp_server/auth.py`, which wires up the JWT validation `walkthrough/02-Security/README.md` already sketched: it verifies a bearer token's RS256 signature against a tenant's JWKS (Azure Entra ID), checks expiry/audience/issuer, and reads the RLS identity from a claim in the verified token rather than trusting anything the client sends directly. A local HMAC mode (`AUTH_DEV_HMAC_SECRET`, with `scripts/generate_dev_token.py` to mint test tokens) lets the sample run without a real Azure AD tenant - it's clearly documented as sample-only, no key rotation or issuer check. If neither mode is configured, every request is rejected; there's no default identity anymore.

One thing worth flagging explicitly: `AZURE_TENANT_ID`/`AZURE_CLIENT_ID` already exist in this repo for the server's *own* outbound Azure OpenAI auth, and `infra/deploy.sh` populates them automatically for that purpose. Entra verification only turns on once `AZURE_AUDIENCE` is also set explicitly, so running the existing deploy script doesn't silently start requiring tokens nobody's set up yet.

**2. `execute_sales_query` now enforces read-only in two layers**

Previously the tool passed the model-supplied SQL string straight to `asyncpg`'s `fetch()`, with a docstring instruction as the only "guardrail." Added a string-level check that rejects anything other than a single `SELECT`/`WITH` statement, plus a `READ ONLY` transaction wrapper so PostgreSQL itself rejects writes even if that check is bypassed - for example a data-modifying CTE (`WITH t AS (INSERT INTO ... RETURNING *) SELECT * FROM t`) parses as read-only text but still writes, and is the reason for the second layer.

**3. Default database role is no longer the superuser**

`.env.template` set `POSTGRES_USER=postgres`, and `postgres` is a superuser on the base image, so it bypasses Row Level Security entirely regardless of what identity a caller presents. Changed the default to `store_manager` (the role `docker-init/init-db.sh` already provisions) and documented that the connecting role must not have `Superuser`/`BYPASSRLS`. Applied the same fix to the `.env` files `infra/deploy.sh`, `infra/deploy.ps1`, and `azd/.env.local` generate, since those - not `.env.template` - are what the documented "Deploy Azure Resources" setup path actually produces.

This interacts with `docker-compose.yml` in a way that's worth calling out: the `postgres` service reads the same `.env` file, and the base Postgres image *also* reads `POSTGRES_USER` to decide what to name the superuser it bootstraps itself with on first init. Switching the app's connection role without accounting for that would have silently renamed the container's own superuser to `store_manager`, breaking every hardcoded `-U postgres` call in `docker-init/init-db.sh`. Pinned `POSTGRES_USER=postgres` for the `postgres` service specifically so the two stay independent.

**4. `store_manager` gets `SELECT` only, not `ALL PRIVILEGES`**

`docker-init/init-db.sh` ran `GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA retail TO store_manager` after restoring the backup, overwriting the `SELECT`-only grants the backup's own DDL had just set. Replaced it with an explicit `GRANT SELECT` (and the `GRANT USAGE ON SCHEMA` it depends on), so the role stays read-only regardless of what the backup grants on its own.

**5. Corrected the README's description of the all-stores UUID**

The Security Considerations section called `00000000-0000-0000-0000-000000000000` "limited access," while the table above it called the same value "all store access" - only the table was right. Reworded both to say plainly that it's an unconditional bypass across every store's data, matching the actual RLS policy behavior, and to note it should be treated like an admin credential rather than a default.

Also updated `.vscode/mcp.json` and the matching README/Sample_Walkthrough examples to send the new `Authorization: Bearer` token instead of the old header, using VS Code's input-prompt mechanism rather than hardcoding a token in a checked-in file (tokens expire; a static one would go stale).

## Testing

Ran the full stack locally with `docker compose up` against the backup file this repo ships, and drove the running server directly over HTTP (no mocks):

- `\du` shows `store_manager` with no `Superuser`/`Bypass RLS` attributes, and `postgres` retaining them (unaffected, since it's still needed for the container's own bootstrap and `docker-init/init-db.sh`'s internal provisioning).
- `\dp retail.customers` shows `store_manager=r/postgres` (`SELECT` only) after restore, versus `arwdDxtm` before this change.
- A request with no `Authorization` header, an expired token, or a malformed one all get rejected with a clear error, on all three DB-backed tools.
- A valid token scoped to Seattle returns exactly 20,340 customers; a valid token carrying the all-stores UUID returns all 50,000 - both match the counts in the original report.
- `INSERT`, `DROP TABLE`, and a stacked `SELECT 1; DROP TABLE ...` are all rejected by the string-level check.
- A data-modifying CTE bypasses that check as expected, but fails at the database with `cannot execute SELECT in a read-only transaction`, and the customer count is confirmed unchanged afterward.
- Ordinary `SELECT`/`WITH` queries, and the schema-lookup tool, work normally with a valid token.

I couldn't test against a real Azure Entra ID tenant (no test tenant available), so the RS256/JWKS verification path is covered by unit tests instead: a self-signed key pair standing in for a JWKS response, checking that a validly-signed token is accepted and that wrong audience, wrong issuer, a different signing key, and an `alg: none` token are all rejected. I'm being explicit about this distinction rather than implying the Entra path got the same live coverage as the HMAC path did.

## Scope note

I focused the doc updates on the files that are either directly load-bearing (`.vscode/mcp.json`) or presented as tracking the actual shipped code (README.md, Sample_Walkthrough.md's "Component Breakdown" section). The per-module walkthrough docs (`03-Setup`, `05-MCP-Server`, `12-Best-Practices`) still show the old `x-rls-user-id`-only examples in a few places - they were already somewhat illustrative rather than kept in exact sync with `mcp_server/` (e.g. `05-MCP-Server`'s own `get_rls_user_id` snippet didn't match the shipped function's signature even before this PR), so I left them for a follow-up rather than rewriting a large amount of narrative content in the same PR as the code change.
